### PR TITLE
GitHub actions needs the environment specified; delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @BridgeDigitalHealth/bridge-developers

--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -25,6 +25,7 @@ jobs:
     name: Upload files to S3 bucket
     runs-on: ubuntu-latest
     needs: pre-commit
+    environment: ${{ github.ref_name }}
     steps:
 
       - name: Setup code, pipenv, aws
@@ -156,6 +157,7 @@ jobs:
     name: Deploy trunk using sceptre
     runs-on: ubuntu-latest
     needs: upload-files
+    environment: ${{ github.ref_name }}
     steps:
       - name: Setup code, pipenv, aws
         uses: Sage-Bionetworks/action-pipenv-aws-setup@v1


### PR DESCRIPTION
It seems that Environment always needs to be specified even if there's only one environment.

It looks like the only thing CODEOWNERS does is automatically assign reviews, which is not necessary in our workflow.